### PR TITLE
fix: disable materialize_ttl_after_modify on MODIFY COLUMN

### DIFF
--- a/migrator.go
+++ b/migrator.go
@@ -300,7 +300,7 @@ func (m Migrator) AlterColumn(value interface{}, field string) error {
 	return m.RunWithValue(value, func(stmt *gorm.Statement) error {
 		if field := stmt.Schema.LookUpField(field); field != nil {
 			clusterOpts := m.extractClusterOption()
-			sQL := fmt.Sprintf("ALTER TABLE ?%s MODIFY COLUMN ? ?", clusterOpts)
+			sQL := fmt.Sprintf("ALTER TABLE ?%s MODIFY COLUMN ? ? SETTINGS materialize_ttl_after_modify = 0", clusterOpts)
 			return m.DB.Exec(
 				sQL,
 				clause.Table{Name: stmt.Table},


### PR DESCRIPTION
## Summary

- Add `SETTINGS materialize_ttl_after_modify = 0` to the `ALTER TABLE ... MODIFY COLUMN` statement in `AlterColumn()`
- Prevents ClickHouse from triggering a full TTL recomputation on all existing rows when a column's TTL expression is modified during schema migration
- Without this setting, modifying a column with TTL on a large table can cause significant I/O and CPU overhead as ClickHouse eagerly materializes the new TTL for every existing row